### PR TITLE
feat(insert logic): Change insertion logic from ContactGUID to ContactEmail

### DIFF
--- a/src/Kentico.Xperience.Contacts.Importer/Services/ImportService/ImportService.cs
+++ b/src/Kentico.Xperience.Contacts.Importer/Services/ImportService/ImportService.cs
@@ -32,7 +32,7 @@ public class ImportService(
         /// </summary>
         public ContactInfoMap()
         {
-            Map(m => m.ContactGUID);
+            Map(m => m.ContactGUID).Optional().Default(Guid.Empty);
             Map(m => m.ContactCreated);
             Map(m => m.ContactFirstName);
             Map(m => m.ContactLastName);
@@ -49,7 +49,7 @@ public class ImportService(
 #pragma warning disable S3459
 #pragma warning disable S1144
         // ReSharper disable once InconsistentNaming // kentico naming convention
-        public Guid ContactGUID { get; set; }
+        public string ContactEmail { get; set; } = "";
 #pragma warning restore S3459
 #pragma warning restore S1144
     }
@@ -58,7 +58,7 @@ public class ImportService(
     private sealed class SimplifiedMap : ClassMap<ContactDeleteArgument>
     {
 #pragma warning disable S1144
-        public SimplifiedMap() => Map(m => m.ContactGUID);
+        public SimplifiedMap() => Map(m => m.ContactEmail);
 #pragma warning restore S1144
     }
 
@@ -113,15 +113,15 @@ public class ImportService(
 
         int totalProcessed = 0;
 
-        IEnumerable<List<Guid>> Pipe2TransformBatches(IEnumerable<ContactDeleteArgument> models)
+        IEnumerable<List<string>> Pipe2TransformBatches(IEnumerable<ContactDeleteArgument> models)
         {
-            var currentBatch = new List<Guid>(context.BatchSize);
+            var currentBatch = new List<string>(context.BatchSize);
 
             foreach (var item in models)
             {
                 try
                 {
-                    currentBatch.Add(item.ContactGUID);
+                    currentBatch.Add(item.ContactEmail);
                 }
                 catch (Exception ex)
                 {
@@ -242,9 +242,9 @@ public class ImportService(
             }
         }
 
-        var contactGuids = (await contactInfoProvider.Get()
-            .Column(nameof(ContactInfo.ContactGUID))
-            .GetListResultAsync<Guid>())
+        var contactEmails = (await contactInfoProvider.Get()
+            .Column(nameof(ContactInfo.ContactEmail))
+            .GetListResultAsync<string>())
             .ToHashSet();
 
         var config = new CsvConfiguration(CultureInfo.InvariantCulture)
@@ -270,7 +270,7 @@ public class ImportService(
             {
                 try
                 {
-                    currentBatch.Add((item, !contactGuids.Contains(item.ContactGUID)));
+                    currentBatch.Add((item, !contactEmails.Contains(item.ContactEmail)));
                 }
                 catch (Exception ex)
                 {
@@ -345,9 +345,9 @@ public class ImportService(
     }
 
 
-    private Task DeletedContactsAsync(List<Guid> contactGuids, int batchLimit)
+    private Task DeletedContactsAsync(List<string> contactEmails, int batchLimit)
     {
-        if (contactGuids.Count == 0)
+        if (contactEmails.Count == 0)
         {
             return Task.CompletedTask;
         }
@@ -355,7 +355,7 @@ public class ImportService(
         return Task.Run(async () =>
         {
             var whereCondition = new WhereCondition()
-                .WhereIn(nameof(ContactInfo.ContactGUID), contactGuids);
+                .WhereIn(nameof(ContactInfo.ContactEmail), contactEmails);
             // if results are needed we can run SP ([dbo].[Proc_OM_Contact_MassDelete]) manually, it returns list of deleted contacts
             await contactsBulkDeletionService.BulkDelete(whereCondition, batchLimit);
         });

--- a/src/Kentico.Xperience.Contacts.Importer/Services/ImportService/ImportService.cs
+++ b/src/Kentico.Xperience.Contacts.Importer/Services/ImportService/ImportService.cs
@@ -33,12 +33,12 @@ public class ImportService(
         public ContactInfoMap()
         {
             Map(m => m.ContactGUID).Optional().Default(Guid.Empty);
-            Map(m => m.ContactCreated);
-            Map(m => m.ContactFirstName);
-            Map(m => m.ContactLastName);
+            Map(m => m.ContactCreated).Optional().Default(DateTime.Now);
+            Map(m => m.ContactFirstName).Optional();
+            Map(m => m.ContactLastName).Optional();
             Map(m => m.ContactEmail);
-            Map(m => m.ContactAddress1);
-            Map(m => m.ContactMiddleName);
+            Map(m => m.ContactAddress1).Optional();
+            Map(m => m.ContactMiddleName).Optional();
         }
     }
 
@@ -242,7 +242,7 @@ public class ImportService(
             }
         }
 
-        var contactEmails = (await contactInfoProvider.Get()
+        var contactGuids = (await contactInfoProvider.Get()
             .Column(nameof(ContactInfo.ContactEmail))
             .GetListResultAsync<string>())
             .ToHashSet();
@@ -270,7 +270,7 @@ public class ImportService(
             {
                 try
                 {
-                    currentBatch.Add((item, !contactEmails.Contains(item.ContactEmail)));
+                    currentBatch.Add((item, !contactGuids.Contains(item.ContactEmail)));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary

Switches bulk insertion from ContactGUID-based deduplication to ContactEmail-based deduplication.
Previously, bulk insertion relied on ContactGUID, which required digital marketers to already know the existing GUIDs in order to avoid inserting duplicate contacts. This change updates the logic to match on ContactEmail instead, so only contacts not already present in the system are inserted. This removes the need for prior GUID knowledge and prevents duplicates from being added.

## Also resolves #22

Optional column headers were documented but, when absent from the incoming CSV, triggered the an exception on import. This is fixed by marking those columns as optional in the class map ([CsvHelper optional maps](https://joshclose.github.io/CsvHelper/examples/configuration/class-maps/optional-maps/)), so import no longer fails when they aren't present.